### PR TITLE
Feat : 영화 OpenAPI 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,12 +57,11 @@ dependencies {
     annotationProcessor ("org.projectlombok:lombok:1.18.20")
     implementation ("org.springframework.boot:spring-boot-starter-data-redis")
 
-
+//    runtimeOnly("com.h2database:h2")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
     runtimeOnly("org.postgresql:postgresql")
     implementation ("org.springframework.boot:spring-boot-starter-thymeleaf")
-
 
     // 테스트 코드
     runtimeOnly("com.h2database:h2")

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/api/service/ApiService.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/api/service/ApiService.kt
@@ -1,0 +1,8 @@
+package org.spartaa3.movietogather.domain.api.service
+
+import org.spartaa3.movietogather.domain.api.service.dto.response.MovieResponse
+import org.springframework.data.domain.SliceImpl
+
+interface ApiService {
+    fun getPopularMoviesList(page: Int): SliceImpl<MovieResponse>
+}

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/api/service/TmdbApiService.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/api/service/TmdbApiService.kt
@@ -1,0 +1,96 @@
+package org.spartaa3.movietogather.domain.api.service
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.spartaa3.movietogather.domain.api.service.dto.response.GenreResponse
+import org.spartaa3.movietogather.domain.api.service.dto.response.MovieListResponse
+import org.spartaa3.movietogather.domain.api.service.dto.response.MovieResponse
+import org.spartaa3.movietogather.domain.review.repository.ReviewRepository
+import org.spartaa3.movietogather.global.exception.ModelNotFoundException
+import org.spartaa3.movietogather.infra.api.ApiProperties
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClient
+
+@Service
+class TmdbApiService (
+    private val apiProperties: ApiProperties,
+    private val reviewRepository: ReviewRepository
+): ApiService {
+    val restClient: RestClient = RestClient.create()
+    val objectMapper = jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false) // 정의되지 않은 필드 무시
+
+
+    // 인기 영화 데이터 목록 호출
+    override fun getPopularMoviesList(page: Int): SliceImpl<MovieResponse> {
+        val url = getUrl(page)
+
+        val result = restClient.get()
+            .uri(url)
+            .retrieve()
+            .body(String::class.java)
+            ?: throw ModelNotFoundException("movie", 1) // 예외처리항목 -> 다른 이슈로 정리
+
+
+        val response: MovieListResponse = result.let { objectMapper.readValue(it, MovieListResponse::class.java)}
+
+        return matchGenreNames(response)
+    }
+
+    // url 작성 (확장 시 프로퍼티로 받아 사용)
+    private fun getUrl(page: Int): String {
+        return "${apiProperties.popularUrl}" +
+                "?${getDefaultUrlParameter()}" +
+                "&page=${page}" +
+                "&api_key=${apiProperties.key}"
+    }
+
+    // Default 요청 인자
+    private fun getDefaultUrlParameter(): String {
+        return "?include_adult=false" +
+                "&language=ko-KO" +
+                "&include_video=false" +
+                "&region=140"
+    }
+
+
+    // 장르 id 기반 장르명 반환
+    private fun matchGenreNames(movieListResponse: MovieListResponse): SliceImpl<MovieResponse> {
+        val genreResponse = getGenres()
+
+//        movieListResponse.results.forEach {
+//            it.genreNames.addAll(
+//                it.genre_ids.mapNotNull { id ->
+//                    genreResponse.genres.find {
+//                        it.id == id
+//                    }?.name
+//                }
+//            )
+//        }
+        movieListResponse.results.forEach { movie ->
+            movie.genreNames = movie.genre_ids.mapNotNull { id ->
+                genreResponse.genres.find { genre -> genre.id == id }?.name
+            }.joinToString(", ") // 여러 장르명을 쉼표로 구분하여 하나의 문자열로 결합
+        }
+        return SlicePaging(movieListResponse)
+    }
+
+
+    // 장르 목록 호출
+    private fun getGenres() = restClient.get()
+            .uri("${apiProperties.genreUrl}" +
+                    "?language=ko" +
+                    "&api_key=${apiProperties.key}")
+            .retrieve()
+            .body(String::class.java)
+            ?.let { objectMapper.readValue(it, GenreResponse::class.java)}
+            ?: throw ModelNotFoundException("movie", 1) // 예외처리항목 -> 다른 이슈로 정리
+
+
+    // Slice 페이징
+    private fun SlicePaging(movieListResponse: MovieListResponse): SliceImpl<MovieResponse> {
+        val hasNext: Boolean = movieListResponse.page != movieListResponse.total_pages
+        return SliceImpl(movieListResponse.results, PageRequest.of(movieListResponse.page, movieListResponse.total_pages), hasNext)
+    }
+}

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/api/service/dto/response/GenreResponse.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/api/service/dto/response/GenreResponse.kt
@@ -1,0 +1,10 @@
+package org.spartaa3.movietogather.domain.api.service.dto.response
+
+data class GenreResponse(
+    val genres: List<Genre>
+)
+
+data class Genre(
+    val id: Int,
+    val name: String
+)

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/api/service/dto/response/MovieResponse.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/api/service/dto/response/MovieResponse.kt
@@ -1,0 +1,20 @@
+package org.spartaa3.movietogather.domain.api.service.dto.response
+
+data class MovieResponse(
+    val id: Int,
+    val title: String,
+    val genre_ids: List<Int>,
+    val poster_path: String,
+    var genreNames: String = ""
+) {
+    val posterUrl = "https://image.tmdb.org/t/p/w500$poster_path"
+}
+
+data class MovieListResponse(
+    val results: List<MovieResponse>,
+    val page: Int,
+    val total_pages: Int,
+    val total_results: Int
+)
+
+

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/review/controller/ReviewController.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/review/controller/ReviewController.kt
@@ -1,6 +1,8 @@
 package org.spartaa3.movietogather.domain.review.controller
 
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.spartaa3.movietogather.domain.api.service.ApiService
+import org.spartaa3.movietogather.domain.api.service.dto.response.MovieResponse
 import org.spartaa3.movietogather.domain.review.dto.CreateReviewRequest
 import org.spartaa3.movietogather.domain.review.dto.ReviewResponse
 import org.spartaa3.movietogather.domain.review.dto.UpdateReviewRequest
@@ -8,6 +10,7 @@ import org.spartaa3.movietogather.domain.review.entity.ReviewSearchCondition
 import org.spartaa3.movietogather.domain.review.service.ReviewService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.SliceImpl
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -16,7 +19,8 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/reviews")
 @RestController
 class ReviewController(
-    private val reviewService: ReviewService
+    private val reviewService: ReviewService,
+    private val apiService: ApiService
 ) {
     @GetMapping("/search")
     fun searchReview(
@@ -66,5 +70,10 @@ class ReviewController(
             .status(HttpStatus.NO_CONTENT)
             .build()
     }
+
+    // 영화 데이터 호출
+    @GetMapping("/movies")
+    fun getPopularMoviesList(): SliceImpl<MovieResponse> {
+        return apiService.getPopularMoviesList(1)
+    }
 }
-//

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/review/dto/ReviewRequest.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/review/dto/ReviewRequest.kt
@@ -3,17 +3,17 @@ package org.spartaa3.movietogather.domain.review.dto
 data class CreateReviewRequest (
     val postingTitle: String,
     val star: Double,
-    val movieTitle: String,
-    val movieImg: String,
+//    val movieTitle: String, // 선택된 영화 처리 작업 후 수정 예정
+//    val movieImg: String,
     val contents: String,
-    val genre: String
+//    val genre: String
 )
 
 data class UpdateReviewRequest (
     val postingTitle: String,
     val star: Double,
-    val movieTitle: String,
-    val movieImg: String,
+//    val movieTitle: String,
+//    val movieImg: String,
     val contents: String,
-    val genre: String
+//    val genre: String
 )

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/review/service/ReviewServiceImpl.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/review/service/ReviewServiceImpl.kt
@@ -34,24 +34,24 @@ class ReviewServiceImpl(
             Review(
                 postingTitle = request.postingTitle,
                 star = request.star,
-                movieTitle = request.movieTitle,
-                movieImg = request.movieImg,
+                movieTitle = "", // 선택된 영화 처리 작업 후 수정 예정
+                movieImg = "",
                 contents = request.contents,
-                genre = request.genre
+                genre = ""
             )
         ).toResponse()
     }
 
     override fun updateReview(reviewId: Long, request: UpdateReviewRequest): ReviewResponse {
         val review = reviewRepository.findByIdOrNull(reviewId) ?: throw ReviewNotFoundException("Review", reviewId)
-        val (postingTitle, star, movieTitle, movieImg, contents, genre) = request
+        val (postingTitle, star, contents) = request
 
         review.postingTitle = postingTitle
         review.star = star
-        review.movieTitle = movieTitle
-        review.movieImg = movieImg
+//        review.movieTitle = movieTitle
+//        review.movieImg = movieImg
         review.contents = contents
-        review.genre = genre
+//        review.genre = genre
         return reviewRepository.save(review).toResponse()
     }
 

--- a/src/main/kotlin/org/spartaa3/movietogather/global/config/PropertyConfig.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/global/config/PropertyConfig.kt
@@ -1,0 +1,10 @@
+package org.spartaa3.movietogather.global.config
+
+import org.spartaa3.movietogather.infra.api.ApiProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(ApiProperties::class)
+class PropertyConfig {
+}

--- a/src/main/kotlin/org/spartaa3/movietogather/infra/api/ApiProperties.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/infra/api/ApiProperties.kt
@@ -1,0 +1,10 @@
+package org.spartaa3.movietogather.infra.api
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "api")
+class ApiProperties {
+    lateinit var key: String
+    lateinit var popularUrl: String
+    lateinit var genreUrl: String
+}


### PR DESCRIPTION
-로컬 테스트용 h2 의존성 추가
-apiService 추가
-apiProperties, apiConfig 추가
-movie/genre Response 추가
-review 로직의 영화데이터 주석처리

## 연관 이슈
- closes #7 

## 해당 작업을 한 동기를 설명해주세요
- 영화리뷰, 모임 서비스를 위한 영화 데이터를 호출하기 위함입니다.

## 작업 내용을 상세히 설명해주세요
- [ ] 영화 openapi tmdb 를 활용하여 Popular 영화 목록을 가져와 프로젝트에서 활용할 수 있는 DTO로 반환하는 로직을 작성하였습니다. 
- [ ] 사용자 선택을 기반으로 가져와야 하는 영화제목, 영화이미지, 장르명의 경우 추후 작업을 위해 리뷰로직에서 임시로 주석처리, "" 처리 하였습니다.
 

## 해야할 일
- [ ] 리뷰/모임 생성 시 사용자가 선택한 영화 데이터 자체의  id 기반으로 찾아서 처리 후 리뷰/모임 생성 로직 수정
- [ ] 페이지네이션 확인
- [ ] 값이 null 일 때 임시로 넣은 ModelNotFoundException 의 경우 예외처리 정리 후 수정
- [ ] 영화 목록과 장르 목록의 캐시 전략