### PR TITLE
keyword가 null일때 검색 안되는 문제 해결 및 스크롤 페이징 기능

### DIFF
--- a/src/main/kotlin/org/spartaa3/movietogather/domain/review/controller/ReviewController.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/review/controller/ReviewController.kt
@@ -8,8 +8,8 @@ import org.spartaa3.movietogather.domain.review.dto.ReviewResponse
 import org.spartaa3.movietogather.domain.review.dto.UpdateReviewRequest
 import org.spartaa3.movietogather.domain.review.entity.ReviewSearchCondition
 import org.spartaa3.movietogather.domain.review.service.ReviewService
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.domain.SliceImpl
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -27,7 +27,7 @@ class ReviewController(
         @RequestParam(name = "searchCondition") condition: ReviewSearchCondition,
         @RequestParam(name = "keyword") keyword: String?,
         pageable: Pageable
-    ): ResponseEntity<Page<ReviewResponse>> {
+    ): ResponseEntity<Slice<ReviewResponse>> {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(reviewService.searchReview(condition, keyword, pageable))

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/review/repository/ReviewQueryRepository.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/review/repository/ReviewQueryRepository.kt
@@ -2,9 +2,9 @@ package org.spartaa3.movietogather.domain.review.repository
 
 import org.spartaa3.movietogather.domain.review.entity.Review
 import org.spartaa3.movietogather.domain.review.entity.ReviewSearchCondition
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface ReviewQueryRepository {
-    fun searchReview(condition: ReviewSearchCondition, keyword: String?, pageable: Pageable): Page<Review>
+    fun searchReview(condition: ReviewSearchCondition, keyword: String?, pageable: Pageable): Slice<Review>
 }

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/review/repository/ReviewQueryRepositoryImpl.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/review/repository/ReviewQueryRepositoryImpl.kt
@@ -36,9 +36,12 @@ class ReviewQueryRepositoryImpl : ReviewQueryRepository, QueryDslSupport() {
     }
 
     private fun allCond(condition: ReviewSearchCondition, keyword: String?): BooleanExpression? {
+        if(keyword == null){
+            return review.id.isNotNull
+        }
         return when (condition) {
-            ReviewSearchCondition.MOVIE_TITLE -> review.postingTitle.like("%$keyword%")
-            ReviewSearchCondition.POSTING_TITLE -> review.movieTitle.like("%$keyword%")
+            ReviewSearchCondition.MOVIE_TITLE -> review.movieTitle.like("%$keyword%")
+            ReviewSearchCondition.POSTING_TITLE -> review.postingTitle.like("%$keyword%")
         }
     }
 }

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/review/repository/ReviewQueryRepositoryImpl.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/review/repository/ReviewQueryRepositoryImpl.kt
@@ -5,9 +5,9 @@ import org.spartaa3.movietogather.domain.review.entity.QReview
 import org.spartaa3.movietogather.domain.review.entity.Review
 import org.spartaa3.movietogather.domain.review.entity.ReviewSearchCondition
 import org.spartaa3.movietogather.infra.QueryDslSupport
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -17,22 +17,24 @@ class ReviewQueryRepositoryImpl : ReviewQueryRepository, QueryDslSupport() {
         condition: ReviewSearchCondition,
         keyword: String?,
         pageable: Pageable
-    ): Page<Review> {
-        val totalCount = queryFactory
-            .select(review.count())
-            .from(review)
-            .where(allCond(condition, keyword))
-            .fetchOne() ?: 0L
+    ): Slice<Review> {
+        val pageSize = pageable.pageSize
 
         val contents = queryFactory
             .selectFrom(review)
             .where(allCond(condition, keyword))
             .offset(pageable.offset)
-            .limit(pageable.pageSize.toLong())
+            .limit(pageSize.toLong() + 1)
             .orderBy(review.createdAt.desc())
             .fetch()
 
-        return PageImpl(contents, pageable, totalCount)
+        var hasNext = false
+        if (contents.size > pageSize) {
+            contents.removeAt(pageSize)
+            hasNext = true
+        }
+
+        return SliceImpl(contents, pageable, hasNext)
     }
 
     private fun allCond(condition: ReviewSearchCondition, keyword: String?): BooleanExpression? {

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/review/service/ReviewService.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/review/service/ReviewService.kt
@@ -4,11 +4,11 @@ import org.spartaa3.movietogather.domain.review.dto.CreateReviewRequest
 import org.spartaa3.movietogather.domain.review.dto.ReviewResponse
 import org.spartaa3.movietogather.domain.review.dto.UpdateReviewRequest
 import org.spartaa3.movietogather.domain.review.entity.ReviewSearchCondition
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface ReviewService {
-    fun searchReview(condition: ReviewSearchCondition, keyword: String?, pageable: Pageable): Page<ReviewResponse>
+    fun searchReview(condition: ReviewSearchCondition, keyword: String?, pageable: Pageable): Slice<ReviewResponse>
 
     fun getReviewById(reviewId: Long): ReviewResponse
 

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/review/service/ReviewServiceImpl.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/review/service/ReviewServiceImpl.kt
@@ -9,8 +9,8 @@ import org.spartaa3.movietogather.domain.review.entity.toResponse
 import org.spartaa3.movietogather.domain.review.repository.HeartRepository
 import org.spartaa3.movietogather.domain.review.repository.ReviewRepository
 import org.spartaa3.movietogather.global.exception.ReviewNotFoundException
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -26,7 +26,7 @@ class ReviewServiceImpl(
         condition: ReviewSearchCondition,
         keyword: String?,
         pageable: Pageable
-    ): Page<ReviewResponse> {
+    ): Slice<ReviewResponse> {
         val reviews = reviewRepository.searchReview(condition, keyword, pageable)
         reviews.forEach { it.heart = heartRepository.countHeartByReviewAndCommentsIsNull(it) }
         return reviews.map { it.toResponse() }


### PR DESCRIPTION
## 연관 이슈
- #4

## 해당 작업을 한 동기를 설명해주세요
- keyword가 null일때 검색 안되는 문제 발생
- 무한 스크롤 페이징 기능 추가

## 작업 내용을 상세히 설명해주세요
원인 : keyword가 null인 상태에서 검색하게 되면 null을 하나의 keyword으로 인식해서 발생한것 같음
  - [x] keyword가 null일때 상황을 추가
- [x] page 대신 slice을 사용하여 무한 스크롤 기능 추가