### PR TITLE
Fix : 베스트 리뷰 조회시 무한 순환참조 해결

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     implementation ("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("io.jsonwebtoken:jjwt-api:0.12.3")
     implementation("io.github.cdimascio:dotenv-java:3.0.0") // env
+    implementation("me.paulschwarz:spring-dotenv:4.0.0")
     implementation("org.springframework.boot:spring-boot-starter-websocket") // websocket
     implementation("io.github.microutils:kotlin-logging:3.0.5") // log
 

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/review/controller/ReviewController.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/review/controller/ReviewController.kt
@@ -5,6 +5,7 @@ import org.spartaa3.movietogather.domain.api.service.ApiService
 import org.spartaa3.movietogather.domain.api.service.dto.response.MovieResponse
 import org.spartaa3.movietogather.domain.review.dto.CreateReviewRequest
 import org.spartaa3.movietogather.domain.review.dto.ReviewResponse
+import org.spartaa3.movietogather.domain.review.dto.ReviewsResponse
 import org.spartaa3.movietogather.domain.review.dto.UpdateReviewRequest
 import org.spartaa3.movietogather.domain.review.entity.ReviewSearchCondition
 import org.spartaa3.movietogather.domain.review.service.ReviewService
@@ -23,7 +24,7 @@ class ReviewController(
     private val apiService: ApiService
 ) {
     @GetMapping("/bastTop3")
-    fun bestTopReview(): ResponseEntity<List<ReviewResponse>> {
+    fun bestTopReview(): ResponseEntity<List<ReviewsResponse>> {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(reviewService.bestTopReview())
@@ -34,7 +35,7 @@ class ReviewController(
         @RequestParam(name = "searchCondition") condition: ReviewSearchCondition,
         @RequestParam(name = "keyword") keyword: String?,
         pageable: Pageable
-    ): ResponseEntity<Slice<ReviewResponse>> {
+    ): ResponseEntity<Slice<ReviewsResponse>> {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(reviewService.searchReview(condition, keyword, pageable))

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/review/dto/ReviewsResponse.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/review/dto/ReviewsResponse.kt
@@ -1,0 +1,30 @@
+package org.spartaa3.movietogather.domain.review.dto
+
+import org.spartaa3.movietogather.domain.review.entity.Review
+import java.time.LocalDateTime
+
+data class ReviewsResponse(
+    val id: Long,
+    val postingTitle: String,
+    val genre: String,
+    val movieTitle: String,
+    val movieImg: String,
+    val contents: String,
+    val createdAt: LocalDateTime,
+    val heart: Int
+) {
+    companion object {
+        fun to(review: Review): ReviewsResponse {
+            return ReviewsResponse(
+                id = review.id!!,
+                postingTitle = review.postingTitle,
+                genre = review.genre,
+                movieTitle = review.movieTitle,
+                movieImg = review.movieImg,
+                contents = review.contents,
+                createdAt = review.createdAt,
+                heart = review.heart
+            )
+        }
+    }
+}

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/review/entity/Review.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/review/entity/Review.kt
@@ -1,5 +1,6 @@
 package org.spartaa3.movietogather.domain.review.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import jakarta.persistence.*
 import org.spartaa3.movietogather.domain.comments.entity.Comments
@@ -37,6 +38,7 @@ class Review(
         cascade = [CascadeType.ALL],
         orphanRemoval = true
     )  //추후 Fetch Join 을 이용하여 구현?
+    @JsonIgnore
     var comments: MutableList<Comments> = mutableListOf()
 
 ) : BaseTimeEntity() {

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/review/service/ReviewService.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/review/service/ReviewService.kt
@@ -2,15 +2,16 @@ package org.spartaa3.movietogather.domain.review.service
 
 import org.spartaa3.movietogather.domain.review.dto.CreateReviewRequest
 import org.spartaa3.movietogather.domain.review.dto.ReviewResponse
+import org.spartaa3.movietogather.domain.review.dto.ReviewsResponse
 import org.spartaa3.movietogather.domain.review.dto.UpdateReviewRequest
 import org.spartaa3.movietogather.domain.review.entity.ReviewSearchCondition
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 
 interface ReviewService {
-    fun bestTopReview(): List<ReviewResponse>
+    fun bestTopReview(): List<ReviewsResponse>
 
-    fun searchReview(condition: ReviewSearchCondition, keyword: String?, pageable: Pageable): Slice<ReviewResponse>
+    fun searchReview(condition: ReviewSearchCondition, keyword: String?, pageable: Pageable): Slice<ReviewsResponse>
 
     fun getReviewById(reviewId: Long): ReviewResponse
 

--- a/src/main/kotlin/org/spartaa3/movietogather/domain/review/service/ReviewServiceImpl.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/domain/review/service/ReviewServiceImpl.kt
@@ -2,6 +2,7 @@ package org.spartaa3.movietogather.domain.review.service
 
 import org.spartaa3.movietogather.domain.review.dto.CreateReviewRequest
 import org.spartaa3.movietogather.domain.review.dto.ReviewResponse
+import org.spartaa3.movietogather.domain.review.dto.ReviewsResponse
 import org.spartaa3.movietogather.domain.review.dto.UpdateReviewRequest
 import org.spartaa3.movietogather.domain.review.entity.Review
 import org.spartaa3.movietogather.domain.review.entity.ReviewSearchCondition
@@ -23,15 +24,15 @@ class ReviewServiceImpl(
     private val heartRepository: HeartRepository,
     private val redisRepository: RedisRepository
 ) : ReviewService {
-    override fun bestTopReview(): List<ReviewResponse> {
+    override fun bestTopReview(): List<ReviewsResponse> {
         val bestReviews = redisRepository.getBestReviews()
-        return if (bestReviews != null) bestReviews.map { it.toResponse() }
+        return if (bestReviews != null) bestReviews.map { ReviewsResponse.to(it) }
         else {
             val reviews = reviewRepository.findAll()
             reviews.forEach { it.heart = heartRepository.countHeartByReviewAndCommentsIsNull(it) }
             val bestReviewsFromDB = reviews.sortedByDescending { it.heart }.take(3)
             redisRepository.saveBestReviews(bestReviewsFromDB)
-            bestReviewsFromDB.map { it.toResponse() }
+            bestReviewsFromDB.map { ReviewsResponse.to(it) }
         }
     }
 
@@ -39,10 +40,10 @@ class ReviewServiceImpl(
         condition: ReviewSearchCondition,
         keyword: String?,
         pageable: Pageable
-    ): Slice<ReviewResponse> {
+    ): Slice<ReviewsResponse> {
         val reviews = reviewRepository.searchReview(condition, keyword, pageable)
         reviews.forEach { it.heart = heartRepository.countHeartByReviewAndCommentsIsNull(it) }
-        return reviews.map { it.toResponse() }
+        return reviews.map { ReviewsResponse.to(it) }
     }
 
     override fun getReviewById(reviewId: Long): ReviewResponse {

--- a/src/main/kotlin/org/spartaa3/movietogather/global/objectmapper/MapperConfig.kt
+++ b/src/main/kotlin/org/spartaa3/movietogather/global/objectmapper/MapperConfig.kt
@@ -2,7 +2,9 @@ package org.spartaa3.movietogather.global.objectmapper
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.util.StdDateFormat
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -13,6 +15,8 @@ class MapperConfig {
         val objectMapper = ObjectMapper()
         objectMapper.registerModule(JavaTimeModule())
         objectMapper.disable(SerializationFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS)
+        objectMapper.registerKotlinModule()
+        objectMapper.setDateFormat(StdDateFormat().withColonInTimeZone(true))
         return objectMapper
     }
 }


### PR DESCRIPTION
## 연관 이슈
- #37 

## 해당 작업을 한 동기를 설명해주세요
- 댓글, 모임 을 생성했을때 역직렬화 에러 발생
- 베스트 리뷰 조회시 댓글이 있을경우 무한순환참조가 발생
- 검색 또는 베스트 리뷰 조회시 댓글리스트 조회가 필요없음

## 작업 내용을 상세히 설명해주세요
- [x] objectMapper 내용 추가
- [x] JsonIgnore 어노테이션 추가 -> 객체 직렬화할때 댓글 무시
- [x] ReveiwsResponse 추가